### PR TITLE
chore: About me の文言を変えた

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,10 +35,12 @@ const posts = (await getCollection("activities"))
         <section class="mb-16">
             <h2 class="font-roboto font-bold text-4xl mb-6">私たちについて</h2>
             <p class="text-base md:text-lg leading-relaxed text-gray-700">
-                山と海と大自然に囲まれたこの地 <b>~和歌山~</b> で私たちはのびのびと競プロを強くなりたいのです。
+                和歌山大学公認の競技プログラミングサークルです。2024年12月から活動しています。
             </p>
+
             <p class="text-base md:text-lg leading-relaxed text-gray-700">
-                あとAtCoderの副社長は和歌山大学出身です。
+                現在は10名のメンバーで構成されています。
+                AtCoder様が定期的に開催するプログラミングコンテストのほか、オンサイトコンテストへの参加など、活動は多岐にわたります。
             </p>
         </section>
 


### PR DESCRIPTION
## 概要
ランディングの『私たちについて』の文言を変えた

## 変更内容
`
和歌山大学公認の競技プログラミングサークルです。2024年12月から活動しています。
現在は10名のメンバーで構成されています。 AtCoder様が定期的に開催するプログラミングコンテストのほか、オンサイトコンテストへの参加など、活動は多岐にわたります。
`
に変更した

## 種別
- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

## 動作確認
- [x] ローカルで `bun run dev` が通る
- [x] ビルドエラーがない（`bun run build`）
- [x] 該当ページの表示を確認した

## スクリーンショット
特になし

## レビュワーへ
特になし
