### PR TITLE
chore: Footerのリンクを正しいものにした

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,10 +2,14 @@
 import { Icon } from "astro-icon/components";
 
 const socialLinks = [
-    { name: "simple-icons:x", href: "https://x.com", label: "X (Twitter)" },
+    {
+        name: "simple-icons:x",
+        href: "https://twitter.com/wakayama_mishou",
+        label: "Twitter",
+    },
     {
         name: "simple-icons:github",
-        href: "https://github.com",
+        href: "https://github.com/WCPC",
         label: "GitHub",
     },
 ];

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,8 +4,8 @@ import { Icon } from "astro-icon/components";
 const socialLinks = [
     {
         name: "simple-icons:x",
-        href: "https://twitter.com/wakayama_mishou",
-        label: "Twitter",
+        href: "https://x.com/wakayama_mishou",
+        label: "Twitter (X)",
     },
     {
         name: "simple-icons:github",


### PR DESCRIPTION
## 概要
FooterのGithubとTwitterのロゴのリンクが無効なところにあったから修正

## 変更内容
上記の通り

## 種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認
- [x] ローカルで `bun run dev` が通る
- [x] ビルドエラーがない（`bun run build`）
- [x] 該当ページの表示を確認した

## スクリーンショット
特になし

## レビュワーへ
特になし
