### PR TITLE
feat: indexページの調整

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,33 +26,27 @@ const posts = (await getCollection("activities"))
     <Header />
 
     <!-- Hero -->
-    <section class="w-full text-center py-16 px-5 border-b border-gray-100">
+    <section class="w-full text-center pt-16 px-5">
         <h1 class="font-roboto font-bold text-6xl md:text-8xl mb-3">WCPC</h1>
         <p
             class="font-roboto font-bold text-xl md:text-2xl text-orange-500"
         >
             和歌山大学 競技プログラミングサークル
         </p>
-
-        <!-- <img
-            src="/images/wcpc-hero.webp"
-            alt="WCPC's Hero"
-            class="max-w-xl w-full mx-auto rounded-2xl object-cover shadow-sm"
-            loading="eager"
-        /> -->
     </section>
 
     <div id="about" class="my-5"></div>
 
-    <main class="flex-1 max-w-4xl mx-auto px-5 pb-16 w-full">
+    <main class="flex-1 max-w-4xl mx-auto px-5 py-16 w-full">
         <!-- About -->
         <section class="mb-16">
             <h2 class="font-roboto font-bold text-4xl mb-6">私たちについて</h2>
             <p class="text-base md:text-lg leading-relaxed text-gray-700">
-                山と海と大自然に囲まれたこの地 <b>~和歌山~</b> で私たちはのびのびと競プロを強くなりたいのです。
+                和歌山大学公認の競技プログラミングサークルです。
             </p>
+
             <p class="text-base md:text-lg leading-relaxed text-gray-700">
-                あとAtCoderの副社長は和歌山大学出身です。
+                2024年12月から活動しています。現在は8名のメンバーで構成されています。 AtCoder様が定期的に開催するプログラミングコンテストのほか、オンサイトコンテストへの参加など、活動は多岐にわたります。
             </p>
         </section>
 


### PR DESCRIPTION
- `私たちについて`の文言が戻っていたので、調整
- `私たちについて`を押した時に、タイトルが隠れていたので、調整
- ロゴ(WCPC)と私たちについての間が空きすぎていたので、調整

## 概要
<!-- このPRで何をしたか一言で -->

## 変更内容
- WCPCの下側ボーダーを削除
- WCPCと`私たちについて`の間が空きすぎていたので、`py`からpt`にして隙間を少なくした
- ヘッダーの`私たちについて`をクリックしたときに本文中の`私たちについて`が隠れていたので、`pt`から`py`にすることで調整した

## 種別
- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

## 動作確認
- [x] ローカルで `bun run dev` が通る
- [x] ビルドエラーがない（`bun run build`）
- [x] 該当ページの表示を確認した

## スクリーンショット
<img width="1470" height="956" alt="スクリーンショット 2026-04-19 18 07 18" src="https://github.com/user-attachments/assets/e3d03475-2886-4858-a1b1-5f564a099751" />


## レビュワーへ
隙間開け過ぎとか狭すぎとか感じたら教えてください
