### PR TITLE
fix: ランディングページの記事一覧バッジのレイアウト崩壊を修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -75,31 +75,31 @@ const posts = (await getCollection("activities"))
                             <li>
                                 <a
                                     href={`/activities/${post.id.replace("index.mdx", "")}`}
-                                    class="flex flex-col sm:flex-row sm:items-center gap-3 p-5 rounded-2xl bg-orange-50 hover:bg-orange-100 transition-colors duration-200 no-underline group"
+                                    class="flex items-center gap-3 p-5 rounded-2xl bg-orange-50 hover:bg-orange-100 transition-colors duration-200 no-underline group"
                                 >
-                                    <span class="text-sm text-gray-400 shrink-0 sm:w-28">
-                                        {post.data.date.toLocaleDateString(
-                                            "ja-JP",
-                                        )}
-                                    </span>
-                                    <div class="flex flex-wrap gap-1.5 shrink-0">
-                                        {post.data.tags.map((tag) => (
-                                            <span class="text-xs bg-orange-200 text-orange-700 px-2 py-0.5 rounded-full">
-                                                {tag}
-                                            </span>
-                                        ))}
-                                    </div>
                                     <div class="flex-1 min-w-0">
-                                        <p class="font-roboto font-bold text-gray-900 group-hover:text-orange-500 transition-colors duration-200">
+                                        <div class="flex flex-wrap items-center gap-2 mb-2">
+                                            <span class="text-sm text-gray-400 shrink-0">
+                                                {post.data.date.toLocaleDateString(
+                                                    "ja-JP",
+                                                )}
+                                            </span>
+                                            {post.data.tags.map((tag) => (
+                                                <span class="text-xs bg-orange-200 text-orange-700 px-2 py-0.5 rounded-full">
+                                                    {tag}
+                                                </span>
+                                            ))}
+                                        </div>
+                                        <p class="font-roboto font-bold text-lg text-gray-900 group-hover:text-orange-500 transition-colors duration-200">
                                             {post.data.title}
                                         </p>
                                         {post.data.description && (
-                                            <p class="text-sm text-gray-500 mt-0.5">
+                                            <p class="text-sm text-gray-500 mt-1">
                                                 {post.data.description}
                                             </p>
                                         )}
                                     </div>
-                                    <span class="text-orange-300 group-hover:text-orange-500 transition-colors duration-200 hidden sm:block shrink-0">
+                                    <span class="text-orange-300 group-hover:text-orange-500 transition-colors duration-200 shrink-0">
                                         →
                                     </span>
                                 </a>


### PR DESCRIPTION
closes #13

## 概要
ランディングページの記事一覧でバッジの文字数によりレイアウトが崩れる問題を修正

## 変更内容
- 日付・バッジ・タイトルの横並びレイアウトを廃止
- 日付+バッジを1行目、タイトル・説明を2行目に配置する縦構成に変更
- 行間スペース調整（`mb-2`, `mt-1`）、タイトルフォントサイズを `text-lg` に拡大

## 種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認
- [x] ローカルで `bun run dev` が通る
- [x] ビルドエラーがない（`bun run build`）
- [x] 該当ページの表示を確認した

## スクリーンショット
<img width="1470" height="956" alt="スクリーンショット 2026-04-20 12 10 56" src="https://github.com/user-attachments/assets/78e806c1-035d-4c4f-aeb0-37e707666151" />


## レビュワーへ
特になし