### PR TITLE
chore: 2025を2026に修正

### DIFF
--- a/src/content/activities/abc454-log/index.mdx
+++ b/src/content/activities/abc454-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC454参加記"
-date: 2025-04-18
+date: 2026-04-18
 draft: false
 author: "Caffeineholic"
 tags: ["AtCoder"]

--- a/src/content/activities/abc455-log/index.mdx
+++ b/src/content/activities/abc455-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC455参加記"
-date: 2025-04-25
+date: 2026-04-25
 draft: false
 author: "nsubaru"
 tags: ["AtCoder"]

--- a/src/content/activities/abc456-log/index.mdx
+++ b/src/content/activities/abc456-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC456参加記"
-date: 2025-05-02
+date: 2026-05-02
 draft: false
 author: "Caffeineholic"
 tags: ["AtCoder"]

--- a/src/content/activities/abc457-log/index.mdx
+++ b/src/content/activities/abc457-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC457参加記"
-date: 2025-05-09
+date: 2026-05-09
 draft: false
 author: "ShoboiNamae"
 tags: ["AtCoder"]

--- a/src/content/activities/abc458-log/index.mdx
+++ b/src/content/activities/abc458-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC458参加記"
-date: 2025-05-16
+date: 2026-05-16
 draft: false
 author: "nsubaru"
 tags: ["AtCoder"]

--- a/src/content/activities/abc459-log/index.mdx
+++ b/src/content/activities/abc459-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ABC459参加記"
-date: 2025-05-23
+date: 2026-05-23
 draft: false
 author: "Twil3akine"
 tags: ["AtCoder"]

--- a/src/content/activities/arc219-log/index.mdx
+++ b/src/content/activities/arc219-log/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ARC--219参加記"
-date: 2025-05-10
+date: 2026-05-10
 draft: false
 author: "nsubaru"
 tags: ["AtCoder"]

--- a/src/content/activities/hello-world-2026/index.mdx
+++ b/src/content/activities/hello-world-2026/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "サイトを公開しました"
-date: 2025-04-16
+date: 2026-04-16
 draft: false
 author: "無名"
 tags: ["記事"]

--- a/src/content/activities/sample/index.mdx
+++ b/src/content/activities/sample/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "サンプル"
-date: 2025-04-12
+date: 2026-04-12
 draft: true
 author: "Ware"
 tags: ["ABC"]


### PR DESCRIPTION
## 概要

各記事内のメタデータ内にある、日付の2025を2026に変更

## 変更内容

`grep -l "2025" ./src/ | xargs perl -pi -e "s/2025/2026/g"` をルートディレクトリで実行

## 種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

## 動作確認

- [x] ローカルで `bun run dev` が通る
- [x] ビルドエラーがない（`bun run build`）
- [x] 該当ページの表示を確認した
- [x] `bun run format` を実行したか

## スクリーンショット

特になし

## レビュワーへ

特になし
